### PR TITLE
Batch Methods

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -63,6 +63,12 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>com.h2database</groupId>
+            <artifactId>h2</artifactId>
+            <version>2.2.224</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>com.zaxxer</groupId>
             <artifactId>HikariCP</artifactId>
             <version>5.0.1</version>

--- a/src/main/java/com/cae/rdb/DefaultBasicCrudOperations.java
+++ b/src/main/java/com/cae/rdb/DefaultBasicCrudOperations.java
@@ -350,6 +350,39 @@ public abstract class DefaultBasicCrudOperations<T extends TableSchema, I> imple
         this.writeOnSharedManager(this.getPatchingActionFor(primaryKey, patchingAction), executionContext);
     }
 
+    protected Consumer<EntityManager> getBatchPatchingActionFor(List<I> primaryKeys, Consumer<List<T>> patchingActions){
+        return manager -> {
+            if (primaryKeys == null || primaryKeys.isEmpty()) {
+                return;
+            }
+            if (this.idFieldName == null) {
+                this.idFieldName = this.findIdFieldName();
+            }
+            var hql = "FROM " + this.entityName + " e WHERE e." + this.idFieldName + " IN (:ids)";
+            List<T> instances = manager.createQuery(hql, this.entityType)
+                    .setParameter("ids", primaryKeys)
+                    .getResultList();
+
+            if (instances.size() != primaryKeys.size()) {
+                throw new InternalMappedException(
+                    "Couldn't patch all instances",
+                    "Some instances corresponding to provided IDs were not found."
+                );
+            }
+            patchingActions.accept(instances);
+        };
+    }
+
+    @Override
+    public void batchPatch(List<I> primaryKey, Consumer<List<T>> patchingActions) {
+        this.writeOnStandaloneManager(this.getBatchPatchingActionFor(primaryKey, patchingActions));
+    }
+
+    @Override
+    public void batchPatch(List<I> primaryKey, Consumer<List<T>> patchingActions, ExecutionContext executionContext) {
+        this.writeOnSharedManager(this.getBatchPatchingActionFor(primaryKey, patchingActions), executionContext);
+    }
+
     protected EntityManager initializeEntityManager(){
         return this.getEntityManagerFactoryOrThrow().createEntityManager();
     }

--- a/src/main/java/com/cae/rdb/DefaultBasicCrudOperations.java
+++ b/src/main/java/com/cae/rdb/DefaultBasicCrudOperations.java
@@ -7,10 +7,7 @@ import com.cae.mapped_exceptions.specifics.InternalMappedException;
 import com.cae.rdb.operations.BasicCrudOperations;
 import com.cae.rdb.queries.Param;
 import com.cae.rdb.tables.TableSchema;
-import jakarta.persistence.Entity;
-import jakarta.persistence.EntityManager;
-import jakarta.persistence.EntityManagerFactory;
-import jakarta.persistence.EntityTransaction;
+import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
 
@@ -63,6 +60,8 @@ public abstract class DefaultBasicCrudOperations<T extends TableSchema, I> imple
     @Getter(AccessLevel.PROTECTED)
     protected String entityName;
 
+    private String idFieldName;
+
     protected EntityManagerFactory entityManagerFactory;
 
     protected EntityManagerFactory getEntityManagerFactoryOrThrow(){
@@ -110,6 +109,50 @@ public abstract class DefaultBasicCrudOperations<T extends TableSchema, I> imple
     @Override
     public void deleteById(I primaryKey, ExecutionContext executionContext) {
         this.writeOnSharedManager(this.getDeletingActionFor(primaryKey), executionContext);
+    }
+
+    protected Consumer<EntityManager> getBatchDeletingActionFor(List<I> ids){
+        return manager -> {
+            if (ids == null || ids.isEmpty()) {
+                return;
+            }
+            if (this.idFieldName == null) {
+                this.idFieldName = this.findIdFieldName();
+            }
+            var hql = "DELETE FROM " + this.entityName + " e WHERE e." + this.idFieldName + " IN (:ids)";
+            manager.createQuery(hql)
+                    .setParameter("ids", ids)
+                    .executeUpdate();
+        };
+    }
+
+    @Override
+    public void batchDelete(List<I> ids) {
+        this.writeOnStandaloneManager(this.getBatchDeletingActionFor(ids));
+    }
+
+    @Override
+    public void batchDelete(List<I> ids, ExecutionContext executionContext) {
+        this.writeOnSharedManager(this.getBatchDeletingActionFor(ids), executionContext);
+    }
+
+    private String findIdFieldName() {
+        Class<?> currentClass = this.entityType;
+        while (currentClass != null) {
+            for (java.lang.reflect.Field field : currentClass.getDeclaredFields()) {
+                if (field.isAnnotationPresent(Id.class)) {
+                    if (field.isAnnotationPresent(Column.class)) {
+                        return field.getAnnotation(Column.class).name();
+                    }
+                    return field.getName();
+                }
+            }
+            currentClass = currentClass.getSuperclass();
+        }
+        throw new InternalMappedException(
+                "Couldn't find @Id annotation for entity " + this.entityType.getSimpleName(),
+                "No field is annotated with @Id in the entity class or its superclasses. This is required for batch operations."
+        );
     }
 
     protected Function<EntityManager, Optional<T>> getFindingByIdActionFor(I primaryKey){

--- a/src/main/java/com/cae/rdb/DefaultBasicCrudOperations.java
+++ b/src/main/java/com/cae/rdb/DefaultBasicCrudOperations.java
@@ -13,6 +13,8 @@ import lombok.Getter;
 
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.function.Consumer;
@@ -148,7 +150,7 @@ public abstract class DefaultBasicCrudOperations<T extends TableSchema, I> imple
                 manager.persist(instances.get(i));
                 if (i > 0 && i % batchSize == 0) {
                     manager.flush();
-                    manager.close();
+                    manager.clear();
                 }
             }
         };
@@ -162,6 +164,37 @@ public abstract class DefaultBasicCrudOperations<T extends TableSchema, I> imple
     @Override
     public void batchCreate(List<T> instances, ExecutionContext executionContext) {
         this.writeOnSharedManager(this.getBatchCreatingActionFor(instances), executionContext);
+    }
+
+    protected Function<EntityManager, List<T>> getBatchMergingActionFor(List<T> instances) {
+        return manager -> {
+            if (instances == null || instances.isEmpty()) {
+                return Collections.emptyList();
+            }
+
+            final int batchSize = 30;
+            List<T> mergedInstances = new ArrayList<>();
+
+            for (int i = 0; i < instances.size(); i++) {
+                mergedInstances.add(manager.merge(instances.get(i)));
+
+                if ((i + 1) % batchSize == 0) {
+                    manager.flush();
+                    manager.clear();
+                }
+            }
+            return mergedInstances;
+        };
+    }
+
+    @Override
+    public List<T> batchMerge(List<T> instances, ExecutionContext executionContext) {
+        return this.writeOnSharedManagerReturning(this.getBatchMergingActionFor(instances), executionContext);
+    }
+
+    @Override
+    public List<T> batchMerge(List<T> instances) {
+        return this.writeOnStandaloneManagerReturning(this.getBatchMergingActionFor(instances));
     }
 
     private String findIdFieldName() {

--- a/src/main/java/com/cae/rdb/DefaultBasicCrudOperations.java
+++ b/src/main/java/com/cae/rdb/DefaultBasicCrudOperations.java
@@ -203,7 +203,10 @@ public abstract class DefaultBasicCrudOperations<T extends TableSchema, I> imple
             for (java.lang.reflect.Field field : currentClass.getDeclaredFields()) {
                 if (field.isAnnotationPresent(Id.class)) {
                     if (field.isAnnotationPresent(Column.class)) {
-                        return field.getAnnotation(Column.class).name();
+                        var name = field.getAnnotation(Column.class).name();
+                        if (!name.isEmpty()) {
+                            return name;
+                        }
                     }
                     return field.getName();
                 }

--- a/src/main/java/com/cae/rdb/DefaultBasicCrudOperations.java
+++ b/src/main/java/com/cae/rdb/DefaultBasicCrudOperations.java
@@ -11,6 +11,7 @@ import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
 
+import java.lang.reflect.Field;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
 import java.util.ArrayList;
@@ -200,7 +201,7 @@ public abstract class DefaultBasicCrudOperations<T extends TableSchema, I> imple
     private String findIdFieldName() {
         Class<?> currentClass = this.entityType;
         while (currentClass != null) {
-            for (java.lang.reflect.Field field : currentClass.getDeclaredFields()) {
+            for (Field field : currentClass.getDeclaredFields()) {
                 if (field.isAnnotationPresent(Id.class)) {
                     if (field.isAnnotationPresent(Column.class)) {
                         var name = field.getAnnotation(Column.class).name();

--- a/src/main/java/com/cae/rdb/DefaultBasicCrudOperations.java
+++ b/src/main/java/com/cae/rdb/DefaultBasicCrudOperations.java
@@ -136,6 +136,34 @@ public abstract class DefaultBasicCrudOperations<T extends TableSchema, I> imple
         this.writeOnSharedManager(this.getBatchDeletingActionFor(ids), executionContext);
     }
 
+    protected Consumer<EntityManager> getBatchCreatingActionFor(List<T> instances) {
+        return manager -> {
+            if (instances == null || instances.isEmpty()) {
+                return;
+            }
+
+            final int batchSize = 30;
+
+            for (int i = 0; i < instances.size(); i++) {
+                manager.persist(instances.get(i));
+                if (i > 0 && i % batchSize == 0) {
+                    manager.flush();
+                    manager.close();
+                }
+            }
+        };
+    }
+
+    @Override
+    public void batchCreate(List<T> instances) {
+        this.writeOnStandaloneManager(this.getBatchCreatingActionFor(instances));
+    }
+
+    @Override
+    public void batchCreate(List<T> instances, ExecutionContext executionContext) {
+        this.writeOnSharedManager(this.getBatchCreatingActionFor(instances), executionContext);
+    }
+
     private String findIdFieldName() {
         Class<?> currentClass = this.entityType;
         while (currentClass != null) {

--- a/src/main/java/com/cae/rdb/operations/CreateOperation.java
+++ b/src/main/java/com/cae/rdb/operations/CreateOperation.java
@@ -2,10 +2,13 @@ package com.cae.rdb.operations;
 
 import com.cae.context.ExecutionContext;
 
+import java.util.List;
+
 public interface CreateOperation <E>{
 
     void createNew(E instance);
     void createNew(E instance, ExecutionContext executionContext);
 
-
+    void batchCreate(List<E> instances);
+    void batchCreate(List<E> instances, ExecutionContext executionContext);
 }

--- a/src/main/java/com/cae/rdb/operations/DeleteOperation.java
+++ b/src/main/java/com/cae/rdb/operations/DeleteOperation.java
@@ -2,9 +2,13 @@ package com.cae.rdb.operations;
 
 import com.cae.context.ExecutionContext;
 
+import java.util.List;
+
 public interface DeleteOperation <I>{
 
     void deleteById(I id);
     void deleteById(I id, ExecutionContext executionContext);
 
+    void batchDelete(List<I> ids);
+    void batchDelete(List<I> ids, ExecutionContext executionContext);
 }

--- a/src/main/java/com/cae/rdb/operations/UpdateOperation.java
+++ b/src/main/java/com/cae/rdb/operations/UpdateOperation.java
@@ -2,6 +2,7 @@ package com.cae.rdb.operations;
 
 import com.cae.context.ExecutionContext;
 
+import java.util.List;
 import java.util.function.Consumer;
 
 public interface UpdateOperation <E, I>{
@@ -11,4 +12,6 @@ public interface UpdateOperation <E, I>{
     void patch(I primaryKey, Consumer<E> patchingAction);
     void patch(I primaryKey, Consumer<E> patchingAction, ExecutionContext executionContext);
 
+    List<E> batchMerge(List<E> instances);
+    List<E> batchMerge(List<E> instances, ExecutionContext executionContext);
 }

--- a/src/main/java/com/cae/rdb/operations/UpdateOperation.java
+++ b/src/main/java/com/cae/rdb/operations/UpdateOperation.java
@@ -14,4 +14,6 @@ public interface UpdateOperation <E, I>{
 
     List<E> batchMerge(List<E> instances);
     List<E> batchMerge(List<E> instances, ExecutionContext executionContext);
+    void batchPatch(List<I> primaryKey, Consumer<List<E>> patchingActions);
+    void batchPatch(List<I> primaryKey, Consumer<List<E>> patchingActions, ExecutionContext executionContext);
 }

--- a/src/test/java/com/cae/rdb/test/BatchDeleteIntegrationTest.java
+++ b/src/test/java/com/cae/rdb/test/BatchDeleteIntegrationTest.java
@@ -1,0 +1,164 @@
+package com.cae.rdb.test;
+
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.EntityManagerFactory;
+import org.hibernate.cfg.Configuration;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Properties;
+import java.util.stream.Collectors;
+import java.util.stream.LongStream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class BatchDeleteIntegrationTest {
+
+    private static EntityManagerFactory entityManagerFactory;
+    private TestEntityRepository testEntityRepository;
+
+    @BeforeAll
+    static void setupEntityManagerFactory() {
+        Properties hibernateProperties = new Properties();
+        hibernateProperties.setProperty("hibernate.connection.url", "jdbc:h2:mem:testdb;DB_CLOSE_DELAY=-1");
+        hibernateProperties.setProperty("hibernate.connection.driver_class", "org.h2.Driver");
+        hibernateProperties.setProperty("hibernate.dialect", "org.hibernate.dialect.H2Dialect");
+        hibernateProperties.setProperty("hibernate.hbm2ddl.auto", "create-drop");
+        hibernateProperties.setProperty("hibernate.show_sql", "true");
+        hibernateProperties.setProperty("hibernate.format_sql", "true");
+
+        Configuration configuration = new Configuration();
+        configuration.setProperties(hibernateProperties);
+        configuration.addAnnotatedClass(TestEntity.class);
+
+        entityManagerFactory = configuration.buildSessionFactory();
+    }
+
+    @AfterAll
+    static void closeEntityManagerFactory() {
+        if (entityManagerFactory != null) {
+            entityManagerFactory.close();
+        }
+    }
+
+    @BeforeEach
+    void setup() {
+        testEntityRepository = new TestEntityRepository(entityManagerFactory);
+        clearDatabase();
+    }
+
+    @AfterEach
+    void tearDown() {
+        clearDatabase();
+    }
+
+    private void clearDatabase() {
+        EntityManager manager = entityManagerFactory.createEntityManager();
+        var transaction = manager.getTransaction();
+        try {
+            transaction.begin();
+            manager.createQuery("DELETE FROM TestEntity").executeUpdate();
+            transaction.commit();
+        } catch (Exception e) {
+            if (transaction.isActive()) {
+                transaction.rollback();
+            }
+            throw e;
+        } finally {
+            manager.close();
+        }
+    }
+
+    @Test
+    void shouldBatchDeleteEntitiesByIds() {
+        // Given
+        List<TestEntity> entitiesToCreate = LongStream.rangeClosed(1, 5)
+                .mapToObj(id -> {
+                    TestEntity entity = new TestEntity();
+                    entity.setId(id);
+                    entity.setName("Entity " + id);
+                    return entity;
+                })
+                .collect(Collectors.toList());
+
+        entitiesToCreate.forEach(entity -> testEntityRepository.createNew(entity));
+
+        assertEquals(5, testEntityRepository.retrieveAll().size());
+
+        List<Long> idsToDelete = List.of(2L, 4L);
+
+        // When
+        testEntityRepository.batchDelete(idsToDelete);
+
+        // Then
+        assertEquals(3, testEntityRepository.retrieveAll().size());
+        assertFalse(testEntityRepository.existsById(2L));
+        assertFalse(testEntityRepository.existsById(4L));
+        assertTrue(testEntityRepository.existsById(1L));
+        assertTrue(testEntityRepository.existsById(3L));
+        assertTrue(testEntityRepository.existsById(5L));
+    }
+
+    @Test
+    void shouldHandleBatchDeleteWithEmptyList() {
+        // Given
+        List<TestEntity> entitiesToCreate = LongStream.rangeClosed(1, 3)
+                .mapToObj(id -> {
+                    TestEntity entity = new TestEntity();
+                    entity.setId(id);
+                    entity.setName("Entity " + id);
+                    return entity;
+                })
+                .collect(Collectors.toList());
+
+        entitiesToCreate.forEach(entity -> testEntityRepository.createNew(entity));
+
+        assertEquals(3, testEntityRepository.retrieveAll().size());
+
+        List<Long> emptyIds = List.of();
+
+        // When
+        testEntityRepository.batchDelete(emptyIds);
+
+        // Then
+        assertEquals(3, testEntityRepository.retrieveAll().size()); // No change expected
+        assertTrue(testEntityRepository.existsById(1L));
+        assertTrue(testEntityRepository.existsById(2L));
+        assertTrue(testEntityRepository.existsById(3L));
+    }
+
+    @Test
+    void shouldHandleBatchDeleteWithNonExistentIds() {
+        // Given
+        List<TestEntity> entitiesToCreate = LongStream.rangeClosed(1, 3)
+                .mapToObj(id -> {
+                    TestEntity entity = new TestEntity();
+                    entity.setId(id);
+                    entity.setName("Entity " + id);
+                    return entity;
+                })
+                .collect(Collectors.toList());
+
+        entitiesToCreate.forEach(entity -> testEntityRepository.createNew(entity));
+
+        assertEquals(3, testEntityRepository.retrieveAll().size());
+
+        List<Long> idsToDelete = List.of(2L, 99L, 100L); // 99L and 100L do not exist
+
+        // When
+        testEntityRepository.batchDelete(idsToDelete);
+
+        // Then
+        assertEquals(2, testEntityRepository.retrieveAll().size()); // Only 2L should be deleted
+        assertFalse(testEntityRepository.existsById(2L));
+        assertTrue(testEntityRepository.existsById(1L));
+        assertTrue(testEntityRepository.existsById(3L));
+    }
+}

--- a/src/test/java/com/cae/rdb/test/BatchOperationsIntegrationTest.java
+++ b/src/test/java/com/cae/rdb/test/BatchOperationsIntegrationTest.java
@@ -199,4 +199,86 @@ public class BatchOperationsIntegrationTest {
         // Then
         assertEquals(0, testEntityRepository.retrieveAll().size()); // No change expected
     }
+
+    @Test
+    void shouldBatchMergeUpdatingEntities() {
+        // Given: Create initial entities
+        List<TestEntity> initialEntities = LongStream.rangeClosed(1, 3)
+                .mapToObj(id -> {
+                    TestEntity entity = new TestEntity();
+                    entity.setId(id);
+                    entity.setName("Original Name " + id);
+                    return entity;
+                })
+                .collect(Collectors.toList());
+        testEntityRepository.batchCreate(initialEntities);
+
+        // When: Modify entities and merge
+        List<TestEntity> updatedEntities = initialEntities.stream()
+                .peek(entity -> entity.setName("Updated Name " + entity.getId()))
+                .collect(Collectors.toList());
+        testEntityRepository.batchMerge(updatedEntities);
+
+        // Then: Verify entities were updated
+        assertEquals(3, testEntityRepository.retrieveAll().size());
+        TestEntity updatedEntity1 = testEntityRepository.findById(1L).orElseThrow();
+        assertEquals("Updated Name 1", updatedEntity1.getName());
+        TestEntity updatedEntity3 = testEntityRepository.findById(3L).orElseThrow();
+        assertEquals("Updated Name 3", updatedEntity3.getName());
+    }
+
+    @Test
+    void shouldBatchMergeCreatingAndUpdatingEntities() {
+        // Given: Create initial entities
+        List<TestEntity> initialEntities = LongStream.rangeClosed(1, 2)
+                .mapToObj(id -> {
+                    TestEntity entity = new TestEntity();
+                    entity.setId(id);
+                    entity.setName("Original Name " + id);
+                    return entity;
+                })
+                .collect(Collectors.toList());
+        testEntityRepository.batchCreate(initialEntities);
+
+        // When: Prepare a mixed list of new and updated entities
+        TestEntity entityToUpdate = testEntityRepository.findById(1L).orElseThrow();
+        entityToUpdate.setName("Updated Name 1");
+
+        TestEntity newEntity = new TestEntity();
+        newEntity.setId(3L);
+        newEntity.setName("New Entity 3");
+
+        List<TestEntity> mixedList = List.of(entityToUpdate, newEntity);
+        testEntityRepository.batchMerge(mixedList);
+
+        // Then: Verify state
+        assertEquals(3, testEntityRepository.retrieveAll().size());
+        TestEntity updatedEntity = testEntityRepository.findById(1L).orElseThrow();
+        assertEquals("Updated Name 1", updatedEntity.getName());
+        TestEntity stillOriginalEntity = testEntityRepository.findById(2L).orElseThrow();
+        assertEquals("Original Name 2", stillOriginalEntity.getName());
+        assertTrue(testEntityRepository.existsById(3L));
+    }
+
+    @Test
+    void shouldHandleBatchMergeWithEmptyList() {
+        // Given
+        List<TestEntity> initialEntities = LongStream.rangeClosed(1, 3)
+                .mapToObj(id -> {
+                    TestEntity entity = new TestEntity();
+                    entity.setId(id);
+                    entity.setName("Original Name " + id);
+                    return entity;
+                })
+                .collect(Collectors.toList());
+        testEntityRepository.batchCreate(initialEntities);
+        assertEquals(3, testEntityRepository.retrieveAll().size());
+
+        // When
+        testEntityRepository.batchMerge(List.of());
+
+        // Then
+        assertEquals(3, testEntityRepository.retrieveAll().size()); // No change
+    }
 }
+

--- a/src/test/java/com/cae/rdb/test/BatchOperationsIntegrationTest.java
+++ b/src/test/java/com/cae/rdb/test/BatchOperationsIntegrationTest.java
@@ -19,7 +19,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class BatchDeleteIntegrationTest {
+public class BatchOperationsIntegrationTest {
 
     private static EntityManagerFactory entityManagerFactory;
     private TestEntityRepository testEntityRepository;
@@ -160,5 +160,43 @@ public class BatchDeleteIntegrationTest {
         assertFalse(testEntityRepository.existsById(2L));
         assertTrue(testEntityRepository.existsById(1L));
         assertTrue(testEntityRepository.existsById(3L));
+    }
+
+    @Test
+    void shouldBatchCreateEntities() {
+        // Given
+        List<TestEntity> entitiesToCreate = LongStream.rangeClosed(10, 15)
+                .mapToObj(id -> {
+                    TestEntity entity = new TestEntity();
+                    entity.setId(id);
+                    entity.setName("Batch Created Entity " + id);
+                    return entity;
+                })
+                .collect(Collectors.toList());
+
+        // When
+        testEntityRepository.batchCreate(entitiesToCreate);
+
+        // Then
+        assertEquals(6, testEntityRepository.retrieveAll().size()); // 6 entities (10-15 inclusive)
+        assertTrue(testEntityRepository.existsById(10L));
+        assertTrue(testEntityRepository.existsById(11L));
+        assertTrue(testEntityRepository.existsById(12L));
+        assertTrue(testEntityRepository.existsById(13L));
+        assertTrue(testEntityRepository.existsById(14L));
+        assertTrue(testEntityRepository.existsById(15L));
+    }
+
+    @Test
+    void shouldHandleBatchCreateWithEmptyList() {
+        // Given
+        assertEquals(0, testEntityRepository.retrieveAll().size());
+        List<TestEntity> emptyList = List.of();
+
+        // When
+        testEntityRepository.batchCreate(emptyList);
+
+        // Then
+        assertEquals(0, testEntityRepository.retrieveAll().size()); // No change expected
     }
 }

--- a/src/test/java/com/cae/rdb/test/BatchOperationsIntegrationTest.java
+++ b/src/test/java/com/cae/rdb/test/BatchOperationsIntegrationTest.java
@@ -15,9 +15,7 @@ import java.util.Properties;
 import java.util.stream.Collectors;
 import java.util.stream.LongStream;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class BatchOperationsIntegrationTest {
 
@@ -280,5 +278,86 @@ public class BatchOperationsIntegrationTest {
         // Then
         assertEquals(3, testEntityRepository.retrieveAll().size()); // No change
     }
-}
 
+    @Test
+    void shouldBatchPatchEntities() {
+        // Given
+        List<TestEntity> entitiesToCreate = LongStream.rangeClosed(1, 3)
+                .mapToObj(id -> {
+                    TestEntity entity = new TestEntity();
+                    entity.setId(id);
+                    entity.setName("Original Name " + id);
+                    return entity;
+                })
+                .collect(Collectors.toList());
+        testEntityRepository.batchCreate(entitiesToCreate);
+
+        List<Long> idsToPatch = List.of(1L, 3L);
+        String newName = "Patched Name";
+
+        // When
+        testEntityRepository.batchPatch(idsToPatch, entities ->
+                entities.forEach(entity -> entity.setName(newName))
+        );
+
+        // Then
+        TestEntity patchedEntity1 = testEntityRepository.findById(1L).orElseThrow();
+        assertEquals(newName, patchedEntity1.getName());
+
+        TestEntity unpatchedEntity2 = testEntityRepository.findById(2L).orElseThrow();
+        assertEquals("Original Name 2", unpatchedEntity2.getName());
+
+        TestEntity patchedEntity3 = testEntityRepository.findById(3L).orElseThrow();
+        assertEquals(newName, patchedEntity3.getName());
+    }
+
+    @Test
+    void shouldHandleBatchPatchWithEmptyList() {
+        // Given
+        List<TestEntity> initialEntities = LongStream.rangeClosed(1, 3)
+                .mapToObj(id -> {
+                    TestEntity entity = new TestEntity();
+                    entity.setId(id);
+                    entity.setName("Original Name " + id);
+                    return entity;
+                })
+                .collect(Collectors.toList());
+        testEntityRepository.batchCreate(initialEntities);
+        assertEquals(3, testEntityRepository.retrieveAll().size());
+
+        // When
+        testEntityRepository.batchPatch(List.of(), entities ->
+                entities.forEach(e -> e.setName("This should not happen"))
+        );
+
+        // Then
+        assertEquals(3, testEntityRepository.retrieveAll().size());
+        assertEquals("Original Name 1", testEntityRepository.findById(1L).get().getName());
+        assertEquals("Original Name 2", testEntityRepository.findById(2L).get().getName());
+        assertEquals("Original Name 3", testEntityRepository.findById(3L).get().getName());
+    }
+
+    @Test
+    void shouldThrowExceptionForBatchPatchWithNonExistentIds() {
+        // Given
+        List<TestEntity> entitiesToCreate = LongStream.rangeClosed(1, 2)
+                .mapToObj(id -> {
+                    TestEntity entity = new TestEntity();
+                    entity.setId(id);
+                    entity.setName("Original Name " + id);
+                    return entity;
+                })
+                .collect(Collectors.toList());
+        testEntityRepository.batchCreate(entitiesToCreate);
+
+        List<Long> idsToPatch = List.of(1L, 99L); // 99L does not exist
+
+        // When & Then
+                var exception = assertThrows(com.cae.mapped_exceptions.specifics.InternalMappedException.class, () ->
+                        testEntityRepository.batchPatch(idsToPatch, entities ->
+                                entities.forEach(e -> e.setName("Patched Name"))
+                        )
+                );
+                assertTrue(exception.getDetails().get().contains("Some instances corresponding to provided IDs were not found"));
+    }
+}

--- a/src/test/java/com/cae/rdb/test/TestEntity.java
+++ b/src/test/java/com/cae/rdb/test/TestEntity.java
@@ -1,0 +1,18 @@
+package com.cae.rdb.test;
+
+import com.cae.rdb.tables.TableSchema;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import lombok.Getter;
+import lombok.Setter;
+
+@Entity(name = "TestEntity")
+@Getter
+@Setter
+public class TestEntity implements TableSchema {
+
+    @Id
+    private Long id;
+    private String name;
+
+}

--- a/src/test/java/com/cae/rdb/test/TestEntityRepository.java
+++ b/src/test/java/com/cae/rdb/test/TestEntityRepository.java
@@ -1,0 +1,12 @@
+package com.cae.rdb.test;
+
+import com.cae.rdb.DefaultBasicCrudOperations;
+import jakarta.persistence.EntityManagerFactory;
+
+public class TestEntityRepository extends DefaultBasicCrudOperations<TestEntity, Long> {
+
+    public TestEntityRepository(EntityManagerFactory entityManagerFactory) {
+        this.entityManagerFactory = entityManagerFactory;
+    }
+
+}


### PR DESCRIPTION
This PR adds the following methods for DefaultCrudOperations:

- `batchCreate(List<T> instances)`
- `batchCreate(List<T> instances, ExecutionContext executionContext)`
- `batchDelete(List<I> ids)`
- `batchDelete(List<I> ids, ExecutionContext executionContext`
- `batchMerge(List<T> instances)`
- `batchMerge(List<T> instances, ExecutionContext executionContext)`
- `batchPatch(List<I> primaryKeys, Consumer<List<E>> patchingActions)`
- `batchPatch(List<I> primaryKeys, Consumer<List<E>> patchingActions, ExecutionContext executionContext)` 

Everything was tested at `com.cae.rdb.test.BatchOperationsIntegrationTest`
<img width="572" height="312" alt="image" src="https://github.com/user-attachments/assets/509b7958-8bf4-453e-b343-164023cc6a84" />

Machine:
Windows 10 19045.3324
11th Gen Intel(R) Core(TM) i5-1135G7 @ 2.40GHz  2.42 GHz x64-based processor
16.0 GB RAM (15.8 GB usable)

Development Enviroment:
OpenJDK 17 Eclipse Temurin